### PR TITLE
ci(workflows): labeledイベント処理を追加

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -2,7 +2,7 @@ name: 🤖 AI Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled]
 
 permissions:
   contents: read
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.draft == false &&
-      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'ready_for_review')
+      (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'ready_for_review' || github.event.action == 'labeled')
     
     steps:
       - name: 📥 Checkout repository
@@ -22,21 +22,36 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: 🏷️ Check labels (optional filtering)
+      - name: 🏷️ Check labels (ai-review required)
         id: check-labels
         run: |
-          # オプション: 特定のラベルがある場合のみレビュー実行
-          # ラベルでフィルタリングしない場合は skip_review=false を設定
-          echo "skip_review=false" >> $GITHUB_OUTPUT
+          echo "🏷️ Checking ai-review label..."
           
-          # ラベルフィルタリングを有効にする場合は以下のコメントを外す
-          # LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | tr '\n' ' ')
-          # if [[ "$LABELS" == *"ai-review"* ]]; then
-          #   echo "skip_review=false" >> $GITHUB_OUTPUT
-          # else
-          #   echo "skip_review=true" >> $GITHUB_OUTPUT
-          #   echo "::notice::Skipping AI review - 'ai-review' label not found"
-          # fi
+          if [[ "${{ github.event.action }}" == "labeled" ]]; then
+            # labeledイベント：追加されたラベルが ai-review かチェック
+            ADDED_LABEL="${{ github.event.label.name }}"
+            echo "Added label: $ADDED_LABEL"
+            
+            if [[ "$ADDED_LABEL" == "ai-review" ]]; then
+              echo "✅ ai-review label was added - proceeding with review"
+              echo "skip_review=false" >> $GITHUB_OUTPUT
+            else
+              echo "⏭️ Added label '$ADDED_LABEL' is not ai-review - skipping"
+              echo "skip_review=true" >> $GITHUB_OUTPUT
+            fi
+          else
+            # その他のイベント：現在のPRに ai-review ラベルがあるかチェック
+            LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name' | tr '\n' ' ')
+            echo "Current labels: $LABELS"
+            
+            if [[ "$LABELS" == *"ai-review"* ]]; then
+              echo "✅ ai-review label found - proceeding with review"
+              echo "skip_review=false" >> $GITHUB_OUTPUT
+            else
+              echo "⏭️ ai-review label not found - skipping review"
+              echo "skip_review=true" >> $GITHUB_OUTPUT
+            fi
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!-- AI-GENERATED-CONTENT -->
## 🎫 関連チケット
<!-- チケットのリンクを貼ってください -->
* 該当チケットが差分からは特定できません。

## 💪 実装内容
<!-- このPRで実装した内容を箇条書きで簡潔に書いてください -->
* GitHub Actionsの AI Code Reviewワークフローを改善し、「ai-review」ラベルが付いたPRのみでAIレビューを実行するように変更

## 🎯 実装のポイント
<!-- レビュワーに伝えたい実装のポイントや工夫した点があれば書いてください -->
* PRに「labeled」イベントを追加し、ラベル付与時にもワークフローが実行されるようにした
* ラベル付与イベントの場合と他のイベントの場合で処理を分岐させ、効率的に判定するロジックを実装
* デバッグ用のログ出力を追加し、ラベルチェックの過程を明確に表示するようにした

## 📸 スクリーンショット
<!-- UI の変更を含む場合は、before/after の画像を貼ってください -->
### Before
<!-- ここに変更前の画像 -->

### After
<!-- ここに変更後の画像 -->

## ✅ 動作確認項目
<!-- テストケースや確認した項目を箇条書きで書いてください -->
- [ ] PRをオープンした時に「ai-review」ラベルがあれば、AIレビューが実行される
- [ ] PRを同期した時に「ai-review」ラベルがあれば、AIレビューが実行される
- [ ] PRがレビュー準備完了になった時に「ai-review」ラベルがあれば、AIレビューが実行される
- [ ] PRに「ai-review」ラベルを後から追加した時に、AIレビューが実行される
- [ ] PRに「ai-review」以外のラベルを追加しても、AIレビューは実行されない

## 🚨 注意事項
<!-- 特に注意が必要な点や、リリース時の注意点があれば書いてください -->
* このワークフローはGitHubトークンの権限に依存しているため、適切な権限設定が必要

## 📝 補足
<!-- その他、補足事項があれば書いてください -->
* 従来はすべてのPRに対してAIレビューが実行されていたが、この変更により「ai-review」ラベルが付いたPRのみに限定される
<!-- /AI-GENERATED-CONTENT -->
